### PR TITLE
Potential Postcard Sanity option

### DIFF
--- a/worlds/kh1/Options.py
+++ b/worlds/kh1/Options.py
@@ -389,7 +389,7 @@ class RandomizePostcards(Choice):
     display_name = "Randomize Postcards"
     option_all = 0
     option_chests = 1
-    option_off = 2
+    option_vanilla = 2
 
 class StartingWorlds(Range):
     """

--- a/worlds/kh1/Options.py
+++ b/worlds/kh1/Options.py
@@ -378,6 +378,19 @@ class VanillaEmblemPieces(DefaultOnToggle):
     """
     display_name = "Vanilla Emblem Pieces"
 
+class RandomizePostcards(Choice):
+    """
+    Determines how Postcards are randomized
+
+    All: All Postcards are randomized
+    Chests: Only the 3 Postcards in chests are randomized
+    Off: Postcards are in their original location
+    """
+    display_name = "Randomize Postcards"
+    option_all = 0
+    option_chests = 1
+    option_off = 2
+
 class StartingWorlds(Range):
     """
     Number of random worlds to start with in addition to Traverse Town, which is always available.  Will only consider Atlantica if toggled, and will only consider End of the World if its unlock is set to "Item".
@@ -410,6 +423,7 @@ class KH1Options(PerGameCommonOptions):
     extra_shared_abilities: ExtraSharedAbilities
     exp_zero_in_pool: EXPZeroInPool
     vanilla_emblem_pieces: VanillaEmblemPieces
+    randomize_postcards: RandomizePostcards
     donald_death_link: DonaldDeathLink
     goofy_death_link: GoofyDeathLink
     keyblade_stats: KeybladeStats
@@ -446,6 +460,7 @@ kh1_option_groups = [
         Cups,
         HundredAcreWood,
         VanillaEmblemPieces,
+        RandomizePostcards,
     ]),
     OptionGroup("Levels", [
         EXPMultiplier,

--- a/worlds/kh1/Options.py
+++ b/worlds/kh1/Options.py
@@ -384,7 +384,7 @@ class RandomizePostcards(Choice):
 
     All: All Postcards are randomized
     Chests: Only the 3 Postcards in chests are randomized
-    Off: Postcards are in their original location
+    Vanilla: Postcards are in their original location
     """
     display_name = "Randomize Postcards"
     option_all = 0

--- a/worlds/kh1/Presets.py
+++ b/worlds/kh1/Presets.py
@@ -19,6 +19,7 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         "hundred_acre_wood": False,
         "cups": False,
         "vanilla_emblem_pieces": True,
+        "randomize_postcards": RandomizePostcards.option_all,
         
         "exp_multiplier": 48,
         "level_checks": 100,
@@ -64,6 +65,7 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         "hundred_acre_wood": False,
         "cups": False,
         "vanilla_emblem_pieces": True,
+        "randomize_postcards": RandomizePostcards.option_all,
         
         "exp_multiplier": 48,
         "level_checks": 100,
@@ -109,6 +111,7 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         "hundred_acre_wood": True,
         "cups": True,
         "vanilla_emblem_pieces": False,
+        "randomize_postcards": RandomizePostcards.option_all,
         
         "exp_multiplier": 48,
         "level_checks": 100,
@@ -154,6 +157,7 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         "hundred_acre_wood": False,
         "cups": False,
         "vanilla_emblem_pieces": True,
+        "randomize_postcards": RandomizePostcards.option_all,
         
         "exp_multiplier": 16,
         "level_checks": 0,

--- a/worlds/kh1/__init__.py
+++ b/worlds/kh1/__init__.py
@@ -131,6 +131,8 @@ class KH1World(World):
         prefilled_items = []
         if self.options.vanilla_emblem_pieces:
             prefilled_items = prefilled_items + ["Emblem Piece (Flame)", "Emblem Piece (Chest)", "Emblem Piece (Fountain)", "Emblem Piece (Statue)"]
+        if self.options.randomize_postcards.current_key not in ["all"]:
+            prefilled_items = prefilled_items + ["Postcard"]
         
         total_locations = len(self.multiworld.get_unfilled_locations(self.player))
         
@@ -217,6 +219,18 @@ class KH1World(World):
             self.get_location("Hollow Bastion Entrance Hall Emblem Piece (Statue)").place_locked_item(self.create_item("Emblem Piece (Statue)"))
             self.get_location("Hollow Bastion Entrance Hall Emblem Piece (Fountain)").place_locked_item(self.create_item("Emblem Piece (Fountain)"))
             self.get_location("Hollow Bastion Entrance Hall Emblem Piece (Chest)").place_locked_item(self.create_item("Emblem Piece (Chest)"))
+        if self.options.randomize_postcards.current_key not in ["all"]:
+            self.get_location("Traverse Town Item Shop Postcard").place_locked_item(self.create_item("Postcard"))
+            self.get_location("Traverse Town 1st District Safe Postcard").place_locked_item(self.create_item("Postcard"))
+            self.get_location("Traverse Town Gizmo Shop Postcard 1").place_locked_item(self.create_item("Postcard"))
+            self.get_location("Traverse Town Gizmo Shop Postcard 2").place_locked_item(self.create_item("Postcard"))
+            self.get_location("Traverse Town Item Workshop Postcard").place_locked_item(self.create_item("Postcard"))
+            self.get_location("Traverse Town 3rd District Balcony Postcard").place_locked_item(self.create_item("Postcard"))
+            self.get_location("Traverse Town Geppetto's House Postcard").place_locked_item(self.create_item("Postcard"))
+        if self.options.randomize_postcards.current_key == "off":
+            self.get_location("Traverse Town 1st District Accessory Shop Roof Chest").place_locked_item(self.create_item("Postcard"))
+            self.get_location("Traverse Town 2nd District Boots and Shoes Awning Chest").place_locked_item(self.create_item("Postcard"))
+            self.get_location("Traverse Town 1st District Blue Trinity Balcony Chest").place_locked_item(self.create_item("Postcard"))
 
     def get_filler_item_name(self) -> str:
         weights = [data.weight for data in self.fillers.values()]

--- a/worlds/kh1/__init__.py
+++ b/worlds/kh1/__init__.py
@@ -180,6 +180,9 @@ class KH1World(World):
             elif name == "EXP Zero":
                 if self.options.exp_zero_in_pool:
                     item_pool += [self.create_item(name) for _ in range(0, quantity)]
+            elif name == "Postcard":
+                if self.options.randomize_postcards.current_key == "chests":
+                    item_pool += [self.create_item(name) for _ in range(0, 3)]
             elif name not in prefilled_items:
                 item_pool += [self.create_item(name) for _ in range(0, quantity)]
         
@@ -227,7 +230,7 @@ class KH1World(World):
             self.get_location("Traverse Town Item Workshop Postcard").place_locked_item(self.create_item("Postcard"))
             self.get_location("Traverse Town 3rd District Balcony Postcard").place_locked_item(self.create_item("Postcard"))
             self.get_location("Traverse Town Geppetto's House Postcard").place_locked_item(self.create_item("Postcard"))
-        if self.options.randomize_postcards.current_key == "off":
+        if self.options.randomize_postcards.current_key == "vanilla":
             self.get_location("Traverse Town 1st District Accessory Shop Roof Chest").place_locked_item(self.create_item("Postcard"))
             self.get_location("Traverse Town 2nd District Boots and Shoes Awning Chest").place_locked_item(self.create_item("Postcard"))
             self.get_location("Traverse Town 1st District Blue Trinity Balcony Chest").place_locked_item(self.create_item("Postcard"))


### PR DESCRIPTION
Emboldened by my logic changes getting merged, I wanted to try out adding an option. Feel free to not merge this/let me know what you think of the idea.

Adds an option to change how postcards are randomized:
Any: Current behavior
Chests: Just the 3 originally in chests are randomized/anywhere in the multiworld, the behavior from before the event locations were added
Vanilla: Places all 10 postcards in their original locations

If you like the idea I could see also adding an option for Puppies and maybe spells (on their original locations, shuffled like Denho's rando, or anywhere).
I don't know that this necessarily adds at ton that can't already be done by plando, and also could lead to super early goals with Postcard goal amount option, but I like the idea of having options to make the game more vanilla/effectively have less locations. The overlap with settings like Keyblades Unlock Chests and Postcards goal would lead to seeds where different items like Blue Trinity and Lionheart are Go Mode which I think is fun (it would be interesting to see how vanilla Puppies would reshape required items on a Puppies goal too).