### PR TITLE
Potential logic changes

### DIFF
--- a/worlds/kh1/Rules.py
+++ b/worlds/kh1/Rules.py
@@ -646,7 +646,7 @@ def set_rules(kh1world):
             and
             (
                 has_emblems(state, player, options.keyblades_unlock_chests)
-                or (options.advanced_logic and state.has("High Jump", player, 2) and state.has("Progressive Glide", player))
+                or (state.has("High Jump", player, 2) and state.has("Progressive Glide", player))
                 or (options.advanced_logic and can_dumbo_skip(state, player) and state.has("Progressive Glide", player))
             )
         ))
@@ -700,7 +700,7 @@ def set_rules(kh1world):
             and
             (
                 has_emblems(state, player, options.keyblades_unlock_chests)
-                or (options.advanced_logic and state.has("High Jump", player, 2) and state.has("Progressive Glide", player))
+                or (state.has("High Jump", player, 2) and state.has("Progressive Glide", player))
                 or (options.advanced_logic and can_dumbo_skip(state, player) and state.has("Progressive Glide", player))
             )
         ))

--- a/worlds/kh1/Rules.py
+++ b/worlds/kh1/Rules.py
@@ -267,7 +267,6 @@ def set_rules(kh1world):
         ))
     add_rule(kh1world.get_location("Wonderland Tea Party Garden Bear and Clock Puzzle Chest"),
         lambda state: (
-        
            state.has("Footprints", player)
            or state.has("Progressive Glide", player)
         ))
@@ -704,7 +703,6 @@ def set_rules(kh1world):
                 or (options.advanced_logic and state.has("High Jump", player, 2) and state.has("Progressive Glide", player))
                 or (options.advanced_logic and can_dumbo_skip(state, player) and state.has("Progressive Glide", player))
             )
-            
         ))
     add_rule(kh1world.get_location("Hollow Bastion Waterway Blizzard on Bubble Chest"),
         lambda state: (
@@ -1968,9 +1966,9 @@ def set_rules(kh1world):
                 lambda state: state.has("Oathkeeper", player))
             add_rule(kh1world.get_location("100 Acre Wood Bouncing Spot Under Giant Pot Chest"),
                 lambda state: state.has("Oathkeeper", player))
-        add_rule(kh1world.get_location("Final Ansem"),
-            lambda state: has_defensive_tools(state, player))
-    
+        
+    add_rule(kh1world.get_location("Final Ansem"),
+        lambda state: has_defensive_tools(state, player))
     
     add_rule(kh1world.get_entrance("Wonderland"),
         lambda state: state.has("Wonderland", player) and has_x_worlds(state, player, 2, options.keyblades_unlock_chests))

--- a/worlds/kh1/Rules.py
+++ b/worlds/kh1/Rules.py
@@ -1969,7 +1969,7 @@ def set_rules(kh1world):
             add_rule(kh1world.get_location("100 Acre Wood Bouncing Spot Under Giant Pot Chest"),
                 lambda state: state.has("Oathkeeper", player))
         add_rule(kh1world.get_location("Final Ansem"),
-                lambda state: has_defensive_tools(state, player))
+            lambda state: has_defensive_tools(state, player))
     
     
     add_rule(kh1world.get_entrance("Wonderland"),

--- a/worlds/kh1/Rules.py
+++ b/worlds/kh1/Rules.py
@@ -269,7 +269,7 @@ def set_rules(kh1world):
         lambda state: (
         
            state.has("Footprints", player)
-           or (options.advanced_logic and state.has("Progressive Glide", player))
+           or state.has("Progressive Glide", player)
         ))
     add_rule(kh1world.get_location("Wonderland Tea Party Garden Across From Bizarre Room Entrance Chest"),
         lambda state: (
@@ -696,7 +696,13 @@ def set_rules(kh1world):
     add_rule(kh1world.get_location("Hollow Bastion Lift Stop Heartless Sigil Door Gravity Chest"),
         lambda state: (
             state.has("Progressive Gravity", player)
-            and has_emblems(state, player, options.keyblades_unlock_chests)
+            and
+            (
+                has_emblems(state, player, options.keyblades_unlock_chests)
+                or (options.advanced_logic and state.has("High Jump", player, 2) and state.has("Progressive Glide", player))
+                or (options.advanced_logic and can_dumbo_skip(state, player) and state.has("Progressive Glide", player))
+            )
+            
         ))
     add_rule(kh1world.get_location("Hollow Bastion Waterway Blizzard on Bubble Chest"),
         lambda state: (
@@ -1959,6 +1965,8 @@ def set_rules(kh1world):
                 lambda state: state.has("Oathkeeper", player))
             add_rule(kh1world.get_location("100 Acre Wood Bouncing Spot Under Giant Pot Chest"),
                 lambda state: state.has("Oathkeeper", player))
+        add_rule(kh1world.get_location("Final Ansem"),
+                lambda state: has_defensive_tools(state, player))
     
     
     add_rule(kh1world.get_entrance("Wonderland"),


### PR DESCRIPTION
Bear and Clock Puzzle Chest with Glide in normal logic: a good number of people have asked about this and when I've seen new players play they just go for it and get it anyways.

Lift Stop chest is pretty straightforward advanced logic

Defensive Tools for Final Ansem. I've been a fan of having this just for the sake of Dodge Roll on Ansem 2 but Leaf Bracer and Cura feel like they should be expected for the final phases. Maybe a bit overkill for shortened go mode, but would rather overshoot. Could also see this going on Chernabog too (mostly because I had test gen put Leaf Bracer on it which felt mean)
I suppose to some extent everything is always accessible before the final boss but having it in logic helps shape the playthrough a little.