### PR TITLE
Add command to change communication path

### DIFF
--- a/worlds/kh1/Client.py
+++ b/worlds/kh1/Client.py
@@ -92,6 +92,17 @@ class KH1ClientCommandProcessor(ClientCommandProcessor):
         else:
             self.output("Unknown")
 
+    def _cmd_communication_path(self):
+        """Opens a file browser to allow Linux users to manually set their %LOCALAPPDATA% path"""
+        directory = Utils.open_directory("Select %LOCALAPPDATA% dir", "~/.local/share/Steam/steamapps/compatdata/2552430/pfx/drive_c/users/steamuser/AppData/Local")
+        if directory:
+            directory += "/KH1FM"
+            if not os.path.exists(directory):
+                os.makedirs(directory)
+            self.ctx.game_communication_path = directory
+        else:
+            self.output(self.ctx.game_communication_path)
+
 class KH1Context(CommonContext):
     command_processor: int = KH1ClientCommandProcessor
     game = "Kingdom Hearts"


### PR DESCRIPTION
This PR aims to allow Linux users to manually change the game communication path, as the mod will always be looking in %LOCALAPPDATA%, and there's no easy way to automate access to this folder on Linux.

Kingdom Hearts is officially supported on Deck, and as such the default path is set to where LOCALAPPDATA would be stored on a default setup of Kingdom Hearts 1.5 + 2.5 on steam. The EGS version is not supported, but it can still be run through the Heroic Launcher. I cannot test the EGS version, but since the folder is selected manually, there's no reason why this shouldn't work for Heroic users as well. If the suggested path doesn't exist, it will suggest the default path of $HOME.

I would've liked to set this mod-side, but I have no idea how to access the $HOME directory from Windows, and even if I did, trying to access it through lua would likely be challenging. Not to mention trying to detect that it's running through proton would require trying to find the KH 1.5 + 2.5 dir, which would be near impossible anyway.

I opted to not change any of the original code for this change, but due to this decision, the directory would need to be set every time the client is opened. Any suggestions on how to improve this would be appreciated. Direct edits are fine too.