### PR TITLE
Olympus Cup fixes

### DIFF
--- a/worlds/kh1/Regions.py
+++ b/worlds/kh1/Regions.py
@@ -526,8 +526,9 @@ def create_regions(kh1world):
             regions["Olympus Coliseum"].locations.append("Hades Cup Defeat Behemoth Event")
             regions["Olympus Coliseum"].locations.append("Hades Cup Defeat Hades Event")
             regions["Olympus Coliseum"].locations.append("Olympus Coliseum Defeat Hades Ansem's Report 8")
-            regions["Olympus Coliseum"].locations.append("Olympus Coliseum Defeat Ice Titan Diamond Dust Event")
             regions["Olympus Coliseum"].locations.append("Olympus Coliseum Gates Purple Jar After Defeating Hades")
+        if options.cups.current_key == "hades_cup" and options.super_bosses:
+            regions["Olympus Coliseum"].locations.append("Olympus Coliseum Defeat Ice Titan Diamond Dust Event")
     if options.super_bosses:
         regions["Neverland"].locations.append("Neverland Defeat Phantom Stop Event")
         regions["Agrabah"].locations.append("Agrabah Defeat Kurt Zisa Zantetsuken Event")

--- a/worlds/kh1/Rules.py
+++ b/worlds/kh1/Rules.py
@@ -1435,6 +1435,20 @@ def set_rules(kh1world):
                     "Entry Pass"}, player)
                 and has_x_worlds(state, player, 4, options.keyblades_unlock_chests, difficulty)
             ))
+        add_rule(kh1world.get_location("Hercules Cup Defeat Cloud Event"),
+            lambda state: (
+                state.has_all({
+                    "Hercules Cup",
+                    "Entry Pass"}, player)
+                and has_x_worlds(state, player, 4, options.keyblades_unlock_chests, difficulty)
+            ))
+        add_rule(kh1world.get_location("Hercules Cup Yellow Trinity Event"),
+            lambda state: (
+                state.has_all({
+                    "Hercules Cup",
+                    "Entry Pass"}, player)
+                and has_x_worlds(state, player, 4, options.keyblades_unlock_chests, difficulty)
+            ))
         if options.cups.current_key == "hades_cup":
             add_rule(kh1world.get_location("Complete Hades Cup"),
                 lambda state: (
@@ -1515,26 +1529,18 @@ def set_rules(kh1world):
                         "Entry Pass"}, player)
                     and has_x_worlds(state, player, 7, options.keyblades_unlock_chests, difficulty)
                     and has_defensive_tools(state, player, difficulty)
-                ))
-        add_rule(kh1world.get_location("Hercules Cup Defeat Cloud Event"),
-            lambda state: (
-                state.has_all({
-                    "Phil Cup",
-                    "Pegasus Cup",
-                    "Hercules Cup",
-                    "Entry Pass"}, player)
-                and has_x_worlds(state, player, 4, options.keyblades_unlock_chests, difficulty)
-            ))
-        if options.cups.current_key == "hades_cup":
-            add_rule(kh1world.get_location("Hades Cup Defeat Behemoth Event"),
+                ))            
+            add_rule(kh1world.get_location("Olympus Coliseum Gates Purple Jar After Defeating Hades"),
                 lambda state: (
                     state.has_all({
                         "Phil Cup",
                         "Pegasus Cup",
                         "Hercules Cup",
                         "Entry Pass"}, player)
-                    and has_x_worlds(state, player, 4, options.keyblades_unlock_chests, difficulty)
+                    and has_x_worlds(state, player, 7, options.keyblades_unlock_chests, difficulty)
+                    and has_defensive_tools(state, player, difficulty)
                 ))
+        if options.cups.current_key == "hades_cup" and options.super_bosses:
             add_rule(kh1world.get_location("Olympus Coliseum Defeat Ice Titan Diamond Dust Event"),
                 lambda state: (
                     state.has_all({
@@ -1546,16 +1552,6 @@ def set_rules(kh1world):
                     and has_x_worlds(state, player, 7, options.keyblades_unlock_chests, difficulty)
                     and has_defensive_tools(state, player, difficulty)
                 ))
-            add_rule(kh1world.get_location("Olympus Coliseum Gates Purple Jar After Defeating Hades"),
-                lambda state: (
-                    state.has_all({
-                        "Phil Cup",
-                        "Pegasus Cup",
-                        "Hercules Cup",
-                        "Entry Pass"}, player)
-                    and has_x_worlds(state, player, 7, options.keyblades_unlock_chests, difficulty)
-                    and has_defensive_tools(state, player, difficulty)
-                ))
         add_rule(kh1world.get_location("Olympus Coliseum Olympia Chest"),
             lambda state: (
                 state.has_all({
@@ -1564,8 +1560,8 @@ def set_rules(kh1world):
                     "Hercules Cup",
                     "Entry Pass"}, player)
                 and has_x_worlds(state, player, 4, options.keyblades_unlock_chests, difficulty)
-            ))
-    if options.super_bosses or final_rest_door_requirement == "superbosses":
+            ))    
+    if options.super_bosses:
         add_rule(kh1world.get_location("Neverland Defeat Phantom Stop Event"),
             lambda state: (
                 state.has("Green Trinity", player)


### PR DESCRIPTION
Fix unreachable Hercules Cup location and correcting the rules for them.
Adding back Ice Titan location only being added when superbosses are on
Removed superboss final rest key rules for Phantom/Kurt as the option is gone now (?)