### PR TITLE
KH1: Update Client to send map update information to AP server as bounce packet.

### DIFF
--- a/worlds/kh1/Client.py
+++ b/worlds/kh1/Client.py
@@ -80,6 +80,9 @@ class KH1Context(CommonContext):
         self.death_link: bool = False
         self.item_num: int = 1
         self.remote_location_ids: list[int] = []
+        self.current_world: int = 0
+        self.current_room: int = 0
+        self.last_map_update: float = time.time()
 
         # self.game_communication_path: files go in this path to pass data between us and the actual game
         if "localappdata" in os.environ:
@@ -265,6 +268,23 @@ async def game_watcher(ctx: KH1Context):
                     if st != "nil":
                         if timegm(time.strptime(st, '%Y%m%d%H%M%S')) > ctx.last_death_link and int(time.time()) % int(timegm(time.strptime(st, '%Y%m%d%H%M%S'))) < 10:
                             await ctx.send_death(death_text = "Sora was defeated!")
+                if file.find("mapupdate") > -1:
+                    st = "nil"
+                    world_id = 0
+                    room_id = 0
+                    map_update_parts = file.split("_", -1)
+                    if len(map_update_parts) >= 4:
+                        st = map_update_parts[1] or "nil"
+                        world_id = map_update_parts[2] or 0
+                        room_id = map_update_parts[3] or 0
+                    world_id = int(world_id)
+                    room_id = int(room_id)
+                    if (world_id != ctx.current_world or room_id != ctx.current_room) and st != "nil":
+                        if timegm(time.strptime(st, '%Y%m%d%H%M%S')) > ctx.last_map_update:
+                            await ctx.send_msgs([{"cmd": "Bounce", "slots": [ctx.slot], "data": {"worldId": world_id, "roomId": room_id}}])
+                            ctx.last_map_update = time.time()
+                            ctx.current_world = world_id
+                            ctx.current_room = room_id
                 if file.find("hint") > -1:
                     hint_location_id = int(file.split("hint", -1)[1])
                     if hint_location_id not in ctx.hinted_location_ids:


### PR DESCRIPTION
## What is this fixing or adding?

Adds a new feature to the KH1 client to enable automatic map tab tracking in PopTracker. Updates the game watcher to look for "mapupdate" files in the game communication path. These files contain world and room information about the player's current location. If the player's location has changed since last observed by the game watcher then the client will send a Bounce packet containing the new world and room information. This information can then be received by a map tracker (PopTracker) to update the map tab automatically.

World and room information are both required because "Agrabah" is split between two tabs ("Agrabah" and "Cave of Wonders") in the PopTracker pack. The KH1FM-RANDOMIZER mod is responsible for deciding when to create "mapupdate" files. For those changes see https://github.com/gaithern/KH1FM-RANDOMIZER/pull/8.

This change to the KH1 client can be made safely before or after the corresponding changes to the KH1FM-RANDOMIZER and PopTracker pack. If a player runs these updates without the KH1 randomizer creating mapupdate files then no files will be read and no bounce packets sent by the client. And since bounce packets do not require any response it is safe to send them even if there is no tracker to receive them.

## How was this tested?

I tested the Client changes by connecting to an active KH1 player slot and verifying that "mapupdate" files were being read correctly and corresponding bounce packets were being sent to the AP server. I also tested these changes alongside a modified version of the KH1 randomizer (using changes in https://github.com/gaithern/KH1FM-RANDOMIZER/pull/8) and the PopTracker pack (https://github.com/culk/Kingdom-Hearts-FM-AP-Tracker/tree/auto-map-tab) so that map updates could be observed within PopTracker in real time.

I also tested with multiple KH1 player slots in the same multiworld to verify that map updates were only sent to the correct player slot.

## If this makes graphical changes, please attach screenshots.

Contains no graphical changes.